### PR TITLE
Unescape double backticks in passwords

### DIFF
--- a/cmd/get-entry.go
+++ b/cmd/get-entry.go
@@ -97,7 +97,7 @@ pleasant-cli get entry --path <path> --attachments`,
 
 			pleasant.Exit(en.Username)
 		case cmd.Flags().Changed("password"):
-			pleasant.Exit(pleasant.TrimDoubleQuotes(entry))
+			pleasant.Exit(pleasant.Unescape(pleasant.TrimDoubleQuotes(entry)))
 		default:
 			pleasant.Exit(entry)
 		}

--- a/pleasant/helpers.go
+++ b/pleasant/helpers.go
@@ -433,6 +433,10 @@ func TrimDoubleQuotes(str string) string {
 	return str
 }
 
+func Unescape(str string) string {
+	return strings.ReplaceAll(str, `\\`, `\`)
+}
+
 func Exit(msg ...any) {
 	fmt.Println(msg...)
 	os.Exit(0)


### PR DESCRIPTION
This makes sure that returned passwords that have backticks in them are properly unescaped.

Fixes #8 