### PR TITLE
Unescape double quotes in passwords

### DIFF
--- a/pleasant/helpers.go
+++ b/pleasant/helpers.go
@@ -434,9 +434,8 @@ func TrimDoubleQuotes(str string) string {
 }
 
 func Unescape(str string) string {
-	str = strings.ReplaceAll(str, `\"`, `"`)
-	str = strings.ReplaceAll(str, `\\`, `\`)
-	return str
+	r := strings.NewReplacer(`\\`, `\`, `\"`, `"`)
+	return r.Replace(str)
 }
 
 func Exit(msg ...any) {

--- a/pleasant/helpers.go
+++ b/pleasant/helpers.go
@@ -434,7 +434,9 @@ func TrimDoubleQuotes(str string) string {
 }
 
 func Unescape(str string) string {
-	return strings.ReplaceAll(str, `\\`, `\`)
+	str = strings.ReplaceAll(str, `\"`, `"`)
+	str = strings.ReplaceAll(str, `\\`, `\`)
+	return str
 }
 
 func Exit(msg ...any) {


### PR DESCRIPTION
Hello again !

Looks like we have the same problem with double quotes according to [this](https://www.freeformatter.com/json-escape.html).
I think the other escape sequences are not a concern for passwords in our case.

So here is just a little modification to prevent this escaping, based on your previous modification (#9).

I tested it on my local computer it works fine, please tell me if I can improve anything.
Thanks !