### PR TITLE
Trim trailing slash from folder queries using path

### DIFF
--- a/pleasant/pleasant.go
+++ b/pleasant/pleasant.go
@@ -140,6 +140,10 @@ func GetIdByResourcePath(baseUrl, resourcePath, resourceType, bearerToken string
 		return "", ErrInvalidResourceType
 	}
 
+	if resourceType == "folder" {
+		resourcePath = strings.TrimSuffix(resourcePath, "/")
+	}
+
 	splitPath := strings.Split(resourcePath, "/")
 
 	if splitPath[0] != "Root" {


### PR DESCRIPTION
Fixes an issue where querying folders with a trailing slash would not work (which is not ideal in combination with the autocompletion). Trailing slashes in folder queries using path are now correctly removed.