### PR TITLE
Return completions in alphabetical order

### DIFF
--- a/pleasant/pleasant.go
+++ b/pleasant/pleasant.go
@@ -320,7 +320,7 @@ func CompletePathFlag(toComplete string, completeAll bool) ([]cobra.Completion, 
 		return completions, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	return completions, cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
+	return completions, cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveKeepOrder
 }
 
 func DuplicateEntryExists(baseUrl, jsonString, bearerToken string) (bool, error) {


### PR DESCRIPTION
Always forces completions to be returned in alphabetical order.