### PR TITLE
Fix CGO builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ go.work
 
 # Goreleaser
 dist/
+dist-linux-win/
+dist-macos/
 
 # Nix build output
 result

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,27 +1,63 @@
-# This is an example .goreleaser.yml file with some sensible defaults.
-# Make sure to check the documentation at https://goreleaser.com
+version: 2
+
 before:
   hooks:
-    # You may remove this if you don't use go modules.
     - go mod tidy
+
 builds:
-  - env:
-      - >-
-        {{- if or (eq .Os "darwin") (eq .Os "linux") }}
-          CGO_ENABLED=1
-        {{- else }}
-          CGO_ENABLED=0
-        {{- end }}
+  - id: macos
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=1
+      # Cross compile settings are disabled as MacOS builds can currently only
+      # be built natively
+      # - >-
+      #   {{- if eq .Arch "amd64" }}CC=o64-clang
+      #   {{- else }}CC=oa64-clang
+      #   {{ end }}
+      # - >-
+      #   {{- if eq .Arch "amd64" }}CCX=o64-clang++
+      #   {{- else }}CCX=oa64-clang++
+      #   {{ end }}
+    flags:
+      - -trimpath
+
+  - id: linux
     goos:
       - linux
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=1
+      - >-
+        {{- if eq .Arch "amd64" }}CC=x86_64-linux-gnu-gcc
+        {{- else }}CC=aarch64-linux-gnu-gcc
+        {{ end }}
+      - >-
+        {{- if eq .Arch "amd64" }}CCX=x86_64-linux-gnu-g++
+        {{- else }}CCX=aarch64-linux-gnu-g++
+        {{ end }}
+    flags:
+      - -trimpath
+
+  - id: windows
+    goos:
       - windows
-      - darwin
+    goarch:
+      - amd64
+      - 386
+    env:
+      - CGO_ENABLED=0
     flags:
       - -trimpath
 
 archives:
   - format: tar.gz
-    # this name template makes the OS and Arch compatible with the results of uname.
     name_template: >-
       {{ .ProjectName }}_
       {{- .Version }}_
@@ -30,22 +66,19 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    # use zip for windows archives
     format_overrides:
       - goos: windows
         format: zip
+
 checksum:
   name_template: 'checksums.txt'
+
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
+
 changelog:
   sort: asc
   filters:
     exclude:
       - '^docs:'
       - '^test:'
-
-# The lines beneath this are called `modelines`. See `:help modeline`
-# Feel free to remove those if you don't want/use them.
-# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
-# vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,5 @@
+FROM ghcr.io/goreleaser/goreleaser-cross:v1.24.2
+
+USER root
+
+RUN apt-get update && apt-get install -y libx11-dev && rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,30 @@
-.PHONY: clean build-linux-windows build-mac
+.PHONY: clean build-linux-windows build-macos release
 
 clean: 
-	rm -rf dist/
+	rm -rf dist/ dist-linux-win/ dist-macos/
 
 # Build Linux & Windows versions in Docker
 build-linux-windows:
 	docker build -f Dockerfile.build -t goreleaser-cross-x11 .
 	docker run --rm \
 	  -v "$$PWD:/app" -w /app goreleaser-cross-x11 \
-	  build --config .goreleaser.yaml --id linux --id windows
+	  build --config .goreleaser.yaml --id linux --id windows --snapshot
+	mv dist/ dist-linux-win/
 
-# Build Mac versions natively (must be ran on a mac)
-build-mac:
-	  goreleaser build --config .goreleaser.yaml --id macos
+# Build Mac versions natively (must be ran on MacOS)
+build-macos:
+	goreleaser build --config .goreleaser.yaml --id macos --snapshot
+	mv dist/ dist-macos/
 
+# Merge dist folders into one
+merge:
+	mkdir -p dist/
+	rsync -a --exclude=artifacts.json --exclude=config.yaml dist-linux-win/ dist/
+	rsync -a --exclude=artifacts.json --exclude=config.yaml dist-macos/ dist/
+	jq -s 'add | unique_by(.name, .path)' \
+	  dist-linux-win/artifacts.json dist-macos/artifacts.json > dist/artifacts.json
+	yq eval ' .builds as $$b1 | (load("dist-macos/config.yaml") | .builds) as $$b2 | .builds = ($$b1 + $$b2)' dist-linux-win/config.yaml > dist/config.yaml
+
+# Release the built artifacts
 release: clean build-linux build-native
-	goreleaser release --config .goreleaser.yml --skip=build
+	goreleaser release --config .goreleaser.yaml --skip=build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: clean build-linux-windows build-mac
+
+clean: 
+	rm -rf dist/
+
+# Build Linux & Windows versions in Docker
+build-linux-windows:
+	docker build -f Dockerfile.build -t goreleaser-cross-x11 .
+	docker run --rm \
+	  -v "$$PWD:/app" -w /app goreleaser-cross-x11 \
+	  build --config .goreleaser.yaml --id linux --id windows --snapshot
+
+# Build Mac versions natively (must be ran on a mac)
+build-mac:
+	  goreleaser build --config .goreleaser.yaml --id macos --snapshot
+
+release: clean build-linux build-native
+	goreleaser release --config .goreleaser.yml --skip=build

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ build-linux-windows:
 	docker build -f Dockerfile.build -t goreleaser-cross-x11 .
 	docker run --rm \
 	  -v "$$PWD:/app" -w /app goreleaser-cross-x11 \
-	  build --config .goreleaser.yaml --id linux --id windows --snapshot
+	  build --config .goreleaser.yaml --id linux --id windows
 
 # Build Mac versions natively (must be ran on a mac)
 build-mac:
-	  goreleaser build --config .goreleaser.yaml --id macos --snapshot
+	  goreleaser build --config .goreleaser.yaml --id macos
 
 release: clean build-linux build-native
 	goreleaser release --config .goreleaser.yml --skip=build

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ docker pull ghcr.io/marevers/pleasant-cli:<version>
 
 ### Go
 
-To build with Go, you must have Go installed (version 1.23).
+To build with Go, you must have Go installed (version 1.24).
 
 ```bash
 go build
@@ -217,7 +217,7 @@ It is also possible to run certain commands directly without first building. For
 
 ```bash
 go run . get entry --id <id>
-``` 
+```
 
 ### Nix
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,7 +13,7 @@ var cfgFile string
 var tokenFile string
 
 // Pleasant-CLI version
-var version = "v0.10.1"
+var version = "v0.10.2"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,6 @@ github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9yS
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.14.0 h1:9tH6MapGnn/j0eb0yIXiLjERO8RB6xIVZRDCX7PtqWA=
 github.com/spf13/afero v1.14.0/go.mod h1:acJQ8t0ohCGuMN3O+Pv0V0hgMxNYDlvdk+VTfyZmbYo=
-github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
-github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cast v1.9.2 h1:SsGfm7M8QOFtEzumm7UZrZdLLquNdzFYfIbEXntcFbE=
 github.com/spf13/cast v1.9.2/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
@@ -46,8 +44,6 @@ go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.design/x/clipboard v0.7.1 h1:OEG3CmcYRBNnRwpDp7+uWLiZi3hrMRJpE9JkkkYtz2c=
 golang.design/x/clipboard v0.7.1/go.mod h1:i5SiIqj0wLFw9P/1D7vfILFK0KHMk7ydE72HRrUIgkg=
-golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 h1:Wdx0vgH5Wgsw+lF//LJKmWOJBLWX6nprsMqnf99rYDE=
-golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476/go.mod h1:ygj7T6vSGhhm/9yTpOQQNvuAUFziTH7RUiH74EoE2C8=
 golang.org/x/exp/shiny v0.0.0-20250620022241-b7579e27df2b h1:zELBzk+7ERc6m8BxhzU2VYjp03wlEvi+cIgYQR5H3CI=
 golang.org/x/exp/shiny v0.0.0-20250620022241-b7579e27df2b/go.mod h1:ygj7T6vSGhhm/9yTpOQQNvuAUFziTH7RUiH74EoE2C8=
 golang.org/x/image v0.28.0 h1:gdem5JW1OLS4FbkWgLO+7ZeFzYtL3xClb97GaUzYMFE=


### PR DESCRIPTION
Fixes #31 

There were some problems with the builds requiring CGO. CGO_ENABLED was not getting set to 1 correctly, which caused the versions that require it (Linux and MacOS) to be built without it and error when using `--clip`. Upon fixing that, it was necessary to start using cross-compilers for Linux, which is what this PR adds.

Currently, MacOS cannot be cross compiled yet so it must be compiled locally. The clipboard project is working on removing the CGO requirement, which once merged can again simplify this process (https://github.com/golang-design/clipboard/pull/83).