### PR TITLE
fix: entry/folder creation with --path flag

### DIFF
--- a/pleasant/models.go
+++ b/pleasant/models.go
@@ -40,25 +40,25 @@ type Tag struct {
 }
 
 type Entry struct {
-	Tags     []Tag
-	Id       string
-	Name     string
-	Username string
-	Password string
-	Url      string
-	Notes    string
-	GroupId  string
-	Expires  string
+	Tags     []Tag  `json:"Tags,omitempty"`
+	Id       string `json:"Id,omitempty"`
+	Name     string `json:"Name,omitempty"`
+	Username string `json:"Username,omitempty"`
+	Password string `json:"Password,omitempty"`
+	Url      string `json:"Url,omitempty"`
+	Notes    string `json:"Notes,omitempty"`
+	GroupId  string `json:"GroupId,omitempty"`
+	Expires  string `json:"Expires,omitempty"`
 }
 
 type Folder struct {
-	Children []Entry
-	Tags     []Tag
-	Id       string
-	Name     string
-	ParentId string
-	Notes    string
-	Expires  string
+	Children []Entry `json:"Children,omitempty"`
+	Tags     []Tag   `json:"Tags,omitempty"`
+	Id       string  `json:"Id,omitempty"`
+	Name     string  `json:"Name,omitempty"`
+	ParentId string  `json:"ParentId,omitempty"`
+	Notes    string  `json:"Notes,omitempty"`
+	Expires  string  `json:"Expires,omitempty"`
 }
 
 type FolderOutput struct {


### PR DESCRIPTION
Omits empty fields from entry/folders models by using 'omitempty'. This fixes an issue when the `--path` option is used to create entries or folders.

Entry or folder creation when using path would sometimes add null values to the data object (for example, if no tags are specified then the tag field would be null) and the Pleasant Password Server API does not seem to accept null values.

This ensures that any properties with empty or null values are not marshalled into the data object but removed instead, preventing null values in the JSON.